### PR TITLE
Fix link for Twitter account on link page

### DIFF
--- a/link.html
+++ b/link.html
@@ -121,7 +121,7 @@
 Amazonプライム会員の方は無料でサブスクライブができます。オリジナルバッジ、オリジナル絵文字、アーカイブの視聴等の特典があります。</td>
 </tr>
 <tr>
-<th><a href="Twitter" target="_blank" rel="noopener"><img src="images/icon_twitter.png" alt="Twitter"><br>Twitter</a></th>
+<th><a href="https://twitter.com/Kirara_Mimi" target="_blank" rel="noopener"><img src="images/icon_twitter.png" alt="Twitter"><br>Twitter</a></th>
 <td>生放送の告知や各種お知らせ、日常のつぶやきをしています</td>
 </tr>
 <tr>


### PR DESCRIPTION
On the link page, we could not jump to your Twitter account because incorrect link was specified. So, I fixed it to correct `href`.